### PR TITLE
Added new siwe endpoints

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -4,6 +4,8 @@ package connector
 import (
 	"context"
 	"net/http"
+
+	"github.com/spruceid/siwe-go"
 )
 
 // Connector is a mechanism for federating login to a remote identity service.
@@ -131,4 +133,16 @@ type Web3Connector interface {
 	// Verify checks that the given message was signed by the private key of the given
 	// account.
 	Verify(address, msg, signedMsg string) (identity Identity, err error)
+
+	Valid(address, nonce, redirectUri string, message siwe.Message, signature string) (identity Identity, err error)
+}
+
+type SiweConnector interface {
+	// Infura ID returns the configured Infura ID if one was provided, or else the
+	// empty string.
+	InfuraID() string
+
+	// Valid checks that the given message was signed by the private key of the given
+	// account.
+	Valid(address, nonce, redirectUri string, message siwe.Message, signature string) (identity Identity, err error)
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/imusmanmalik/randomizer v1.0.2
 	github.com/kylelemons/godebug v1.1.0
 	github.com/lib/pq v1.10.7
 	github.com/mattermost/xml-roundtrip-validator v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
+github.com/imusmanmalik/randomizer v1.0.2 h1:B0pPHtArc+Vn4ag2MQeDbTn0gwJ+PAtDkALJG7Js/nE=
+github.com/imusmanmalik/randomizer v1.0.2/go.mod h1:US0lZxMWejL+oIP/YmdNsUpHsbwzIK8SQTwxlvS8z+s=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/server/server.go
+++ b/server/server.go
@@ -364,6 +364,10 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	handleFunc("/auth/{connector}/login", s.handlePasswordLogin)
 	handleWithCORS("/auth/{connector}/generate_challenge", s.handleGenerateChallenge)
 	handleWithCORS("/auth/{connector}/submit_challenge", s.handleSubmitChallenge)
+
+	handleWithCORS("/auth/{connector}/nonce", s.handleGenerateNonce)
+	handleWithCORS("/auth/{connector}/submit_siwe", s.handleSubmitSiwe)
+
 	handleWithCORS("/auth/{connector}/challenge", s.handleChallenge)
 	handleWithCORS("/auth/{connector}/verify", s.handleVerify)
 	handleWithCORS("/auth/{connector}/verify_direct", s.handleVerifyDirect)


### PR DESCRIPTION

#### Overview

This PR is meant to introduce more standard SIWE support for Dex.

#### What this PR does / why we need it

This PR does a couple of things:
1. Standardize login endpoints across clients(5->2)
2. The clients create the message.
3. SIWE RequestID is now used to store the dex request id.

#### Special notes for your reviewer
WIP
#### Does this PR introduce a user-facing change?
This change will cause the following clients to migrate:
1. DIMO Mobile
2. Sample Web App
3. AutoPI?
4. Fleetlogic?

```release-note

```
