### PR TITLE
Fix to return after Login failure in handlers_dimo.go

### DIFF
--- a/server/handlers_dimo.go
+++ b/server/handlers_dimo.go
@@ -244,6 +244,7 @@ func (s *Server) handleVerify(w http.ResponseWriter, r *http.Request) {
 	redirectURL, canSkipApproval, err := s.finalizeLogin(r.Context(), identity, authReq, conn)
 	if err != nil {
 		s.renderErrorJSON(w, http.StatusInternalServerError, "Login failure.")
+		return
 	}
 
 	if canSkipApproval {
@@ -300,6 +301,7 @@ func (s *Server) handleVerifyDirect(w http.ResponseWriter, r *http.Request) {
 	_, _, err = s.finalizeLogin(r.Context(), identity, authReq, conn)
 	if err != nil {
 		s.renderErrorJSON(w, http.StatusInternalServerError, "Login failure.")
+		return
 	}
 
 	// Need to pick up the changes made by finalizeLogin. This is pretty gross!
@@ -390,6 +392,7 @@ func (s *Server) handleSubmitChallenge(w http.ResponseWriter, r *http.Request) {
 	_, _, err = s.finalizeLogin(r.Context(), identity, authReq, conn)
 	if err != nil {
 		s.renderErrorJSON(w, http.StatusInternalServerError, "Login failure.")
+		return
 	}
 
 	// Need to pick up the changes made by finalizeLogin. This is pretty gross!

--- a/server/handlers_dimo_test.go
+++ b/server/handlers_dimo_test.go
@@ -4,9 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/dexidp/dex/connector"
+	"github.com/dexidp/dex/storage"
 )
 
 func TestHandleInvalidFormPOSTCallbacks(t *testing.T) {
@@ -40,5 +48,118 @@ func TestHandleInvalidFormPOSTCallbacks(t *testing.T) {
 		if rr.Code != r.ExpectedCode {
 			t.Fatalf("test %d expected %d, got %d", i, r.ExpectedCode, rr.Code)
 		}
+	}
+}
+
+type stubWeb3Connector struct{}
+
+func (stubWeb3Connector) InfuraID() string { return "" }
+
+func (stubWeb3Connector) Verify(address, msg, signedMsg string) (connector.Identity, error) {
+	return connector.Identity{
+		UserID:        "test-user-id",
+		Username:      "test-user",
+		Email:         "test@example.com",
+		EmailVerified: true,
+	}, nil
+}
+
+type updateAuthRequestErrStorage struct {
+	storage.Storage
+}
+
+func (s *updateAuthRequestErrStorage) UpdateAuthRequest(id string, updater func(storage.AuthRequest) (storage.AuthRequest, error)) error {
+	return errors.New("simulated update auth request error")
+}
+
+// TestHandleSubmitChallengeReturnsAfterFinalizeLoginError verifies that when
+// finalizeLogin returns an error, the response contains only the error JSON
+// and the handler does not fall through to the success path (which would
+// otherwise concatenate a token JSON onto the same response body).
+func TestHandleSubmitChallengeReturnsAfterFinalizeLoginError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	httpServer, srv := newTestServer(ctx, t, func(c *Config) {
+		c.Storage = &updateAuthRequestErrStorage{Storage: c.Storage}
+	})
+	defer httpServer.Close()
+
+	web3Conn := storage.Connector{
+		ID:              "web3-stub",
+		Type:            "mockCallback",
+		Name:            "Web3 Stub",
+		ResourceVersion: "1",
+	}
+	if err := srv.storage.CreateConnector(ctx, web3Conn); err != nil {
+		t.Fatalf("create connector: %v", err)
+	}
+	srv.mu.Lock()
+	srv.connectors[web3Conn.ID] = Connector{
+		ResourceVersion: web3Conn.ResourceVersion,
+		Connector:       stubWeb3Connector{},
+	}
+	srv.mu.Unlock()
+
+	if err := srv.storage.CreateClient(ctx, storage.Client{
+		ID:           "test-client",
+		Secret:       "secret",
+		RedirectURIs: []string{"http://localhost/cb"},
+	}); err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	connData, err := json.Marshal(web3ConnectorData{
+		Address: "0x0000000000000000000000000000000000000001",
+		Nonce:   "test-nonce",
+	})
+	if err != nil {
+		t.Fatalf("marshal connector data: %v", err)
+	}
+
+	authReq := storage.AuthRequest{
+		ID:            storage.NewID(),
+		ClientID:      "test-client",
+		ConnectorID:   web3Conn.ID,
+		ConnectorData: connData,
+		Expiry:        srv.now().Add(10 * time.Minute),
+		RedirectURI:   "http://localhost/cb",
+		Scopes:        []string{"openid"},
+		HMACKey:       []byte("test-hmac-key"),
+	}
+	if err := srv.storage.CreateAuthRequest(ctx, authReq); err != nil {
+		t.Fatalf("create auth request: %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("state", authReq.ID)
+	form.Set("signature", "0x0")
+	form.Set("domain", "http://localhost/cb")
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/auth/web3/submit_challenge", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	srv.handleSubmitChallenge(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status %d, got %d (body=%q)", http.StatusInternalServerError, rr.Code, rr.Body.String())
+	}
+
+	dec := json.NewDecoder(rr.Body)
+
+	var errBody struct {
+		Status  int    `json:"status"`
+		Message string `json:"message"`
+	}
+	if err := dec.Decode(&errBody); err != nil {
+		t.Fatalf("decode first JSON object: %v", err)
+	}
+	if errBody.Message != "Login failure." {
+		t.Fatalf("expected message %q, got %q", "Login failure.", errBody.Message)
+	}
+
+	var trailing json.RawMessage
+	if err := dec.Decode(&trailing); err != io.EOF {
+		t.Fatalf("expected only one JSON object in body, but found a trailing object: err=%v body=%q", err, string(trailing))
 	}
 }


### PR DESCRIPTION
#### Overview

Three `/auth/web3` handlers in `server/handlers_dimo.go` (`handleVerify`,  `handleVerifyDirect`, `handleSubmitChallenge`) call `renderErrorJSON("Login failure.")` when `finalizeLogin` returns an error but do not `return` afterward, so execution falls through to the success path. This PR adds the missing `return` in all three handlers, plus a regression test for `handleSubmitChallenge`.

#### What this PR does / why we need it
When `finalizeLogin` errors, each handler writes a 500 JSON via `renderErrorJSON` but then continues running. The success path writes a second JSON onto the same response, so clients see a body like: 

```json
  {"status":500,"message":"Login failure."}
  {"access_token":"...","token_type":"bearer","expires_in":1209599,"id_token":"..."} 
```

The HTTP status is 500, so client SDKs (`@dimo-network/data-sdk`, `dimo-python-sdk`, axios / requests, etc.) reject the whole response as an error.
                                                                                                                                                                                                                               
The trailing token is also **not** a hidden valid login. The error inside `finalizeLogin` comes from `UpdateAuthRequest`, which is the call that writes `LoggedIn=true` and the user claims onto the `AuthRequest`. The downstream `CreateAuthCode` / `handleToken` then run with empty claims, producing a JWT whose payload looks like:                                                                                                                                                                            
                  
  ```json                                                                                                                                                                                                                      
  {               
    "iss": "https://auth.dimo.zone",
    "provider_id": "web3",
    "sub": "EgR3ZWIz",         // protobuf-encoded {ConnId:"web3", UserId:""}
    "aud": "<client_id>",                                                                                                                                                                                                      
    "iat": ..., "exp": ...,
    "email_verified": false                                                                                                                                                                                                    
    // no email, no preferred_username, no name
  } 
```
              
So the response is doubly broken: a 500 that the client rejects, and (even if the client tried to use it) a token with no UserId that no resource server can authenticate. Returning early after the error is the correct fix.

This was triggered in production by concurrent auth flows from the same wallet against a cold token cache, presumably causing a transient storage conflict in UpdateAuthRequest.

#### Special notes for your reviewer

* The fix itself is one return per handler (3 lines total). 
* The added test: `TestHandleSubmitChallengeReturnsAfterFinalizeLoginError` uses a stub `Web3Connector` and a storage wrapper that fails `UpdateAuthRequest`, then asserts the response body decodes to exactly one JSON object. Without this PR's fix the test fails by detecting a trailing JSON on the body — i.e. it reproduces the actual production symptom.
* Out of scope, possible follow-up: every finalizeLogin error currently becomes a 500. For the default openid email scope this is  correct (the only reachable error is UpdateAuthRequest, after which the request is unusable). But OfflineSessions errors — only reachable with offline_access + RefreshConnector — happen after UpdateAuthRequest has already succeeded, so 500-ing there is overly  aggressive. Splitting fatal vs non-fatal would be a behavior change worth a separate PR.